### PR TITLE
Refactor/#139 change way of save chatting on db

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	//chat
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+	//mongoDB
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 
 	//h2
 	implementation 'com.h2database:h2'

--- a/src/main/java/com/gaduationproject/cre8/Cre8Application.java
+++ b/src/main/java/com/gaduationproject/cre8/Cre8Application.java
@@ -3,8 +3,10 @@ package com.gaduationproject.cre8;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @SpringBootApplication
+@EnableMongoRepositories
 public class Cre8Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/gaduationproject/cre8/app/chat/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/dto/response/MessageResponseDto.java
@@ -1,7 +1,7 @@
 package com.gaduationproject.cre8.app.chat.dto.response;
 
 import com.gaduationproject.cre8.app.chat.dto.request.ChatDto;
-import com.gaduationproject.cre8.domain.chat.entity.Message;
+import com.gaduationproject.cre8.domain.chat.entity.ChattingMessage;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,8 +15,12 @@ public class MessageResponseDto {
     private Long senderId;
     private String contents;
 
-    public static MessageResponseDto of(Message message){
-        return new MessageResponseDto(message.getSender().getId(),message.getContents());
+//    public static MessageResponseDto of(Message message){
+//        return new MessageResponseDto(message.getSender().getId(),message.getContents());
+//    }
+
+    public static MessageResponseDto ofChatMessage(final ChattingMessage chattingMessage){
+        return new MessageResponseDto(chattingMessage.getSenderId(),chattingMessage.getContents());
     }
 
     public static MessageResponseDto ofPayLoad(final Long memberId,final ChatDto chatDto){

--- a/src/main/java/com/gaduationproject/cre8/app/chat/service/ChattingService.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/service/ChattingService.java
@@ -2,8 +2,10 @@ package com.gaduationproject.cre8.app.chat.service;
 
 import com.gaduationproject.cre8.app.chat.dto.request.ChatDto;
 import com.gaduationproject.cre8.app.chat.dto.response.MessageResponseDto;
+import com.gaduationproject.cre8.domain.chat.entity.ChattingMessage;
 import com.gaduationproject.cre8.domain.chat.entity.ChattingRoom;
 import com.gaduationproject.cre8.domain.chat.entity.Message;
+import com.gaduationproject.cre8.domain.chat.repository.ChattingMessageRepository;
 import com.gaduationproject.cre8.domain.chat.repository.ChattingRoomRepository;
 import com.gaduationproject.cre8.domain.chat.repository.MessageRepository;
 import com.gaduationproject.cre8.common.response.error.ErrorCode;
@@ -23,6 +25,7 @@ public class ChattingService {
     private final ChattingRoomRepository chattingRoomRepository;
     private final MessagingService messagingService;
     private final MessageRepository messageRepository;
+    private final ChattingMessageRepository chattingMessageRepository;
 
 
     public void sendMessage(final Long roomId,final ChatDto chatDto,final SimpMessageHeaderAccessor simpMessageHeaderAccessor){
@@ -40,6 +43,12 @@ public class ChattingService {
                 .sender(sender)
                 .contents(chatDto.getMessage())
                 .build());
+
+         chattingMessageRepository.save(ChattingMessage.builder()
+                 .chattingRoomId(chattingRoom.getId())
+                 .senderId(sender.getId())
+                 .contents(chatDto.getMessage())
+                 .build());
 
 
     }

--- a/src/main/java/com/gaduationproject/cre8/app/chat/service/ChattingService.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/service/ChattingService.java
@@ -4,15 +4,14 @@ import com.gaduationproject.cre8.app.chat.dto.request.ChatDto;
 import com.gaduationproject.cre8.app.chat.dto.response.MessageResponseDto;
 import com.gaduationproject.cre8.domain.chat.entity.ChattingMessage;
 import com.gaduationproject.cre8.domain.chat.entity.ChattingRoom;
-import com.gaduationproject.cre8.domain.chat.entity.Message;
 import com.gaduationproject.cre8.domain.chat.repository.ChattingMessageRepository;
 import com.gaduationproject.cre8.domain.chat.repository.ChattingRoomRepository;
-import com.gaduationproject.cre8.domain.chat.repository.MessageRepository;
 import com.gaduationproject.cre8.common.response.error.ErrorCode;
 import com.gaduationproject.cre8.common.response.error.exception.BadRequestException;
 import com.gaduationproject.cre8.common.response.error.exception.NotFoundException;
 import com.gaduationproject.cre8.domain.member.entity.Member;
 import com.gaduationproject.cre8.domain.member.repository.MemberRepository;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
@@ -24,7 +23,7 @@ public class ChattingService {
     private final MemberRepository memberRepository;
     private final ChattingRoomRepository chattingRoomRepository;
     private final MessagingService messagingService;
-    private final MessageRepository messageRepository;
+    //private final MessageRepository messageRepository;
     private final ChattingMessageRepository chattingMessageRepository;
 
 
@@ -38,16 +37,17 @@ public class ChattingService {
 
         messagingService.sendMessage("/sub/chat/room/"+roomId,MessageResponseDto.ofPayLoad(sender.getId(),chatDto));
 
-         messageRepository.save(Message.builder()
-                .chattingRoom(chattingRoom)
-                .sender(sender)
-                .contents(chatDto.getMessage())
-                .build());
+//         messageRepository.save(Message.builder()
+//                .chattingRoom(chattingRoom)
+//                .sender(sender)
+//                .contents(chatDto.getMessage())
+//                .build());
 
          chattingMessageRepository.save(ChattingMessage.builder()
                  .chattingRoomId(chattingRoom.getId())
                  .senderId(sender.getId())
                  .contents(chatDto.getMessage())
+                 .createdAt(LocalDateTime.now())
                  .build());
 
 

--- a/src/main/java/com/gaduationproject/cre8/domain/chat/entity/ChattingMessage.java
+++ b/src/main/java/com/gaduationproject/cre8/domain/chat/entity/ChattingMessage.java
@@ -1,5 +1,7 @@
 package com.gaduationproject.cre8.domain.chat.entity;
 
+import com.fasterxml.jackson.databind.ser.Serializers.Base;
+import com.gaduationproject.cre8.domain.baseentity.BaseEntity;
 import com.gaduationproject.cre8.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.FetchType;
@@ -8,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document(collection = "chatting") // 실제 몽고 DB 컬렉션 이름
+@Document(collection = "chatting") //  몽고 DB 컬렉션 이름
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ChattingMessage {
@@ -29,12 +32,16 @@ public class ChattingMessage {
 
     private String contents;
 
+    private LocalDateTime createdAt;
+
+
     @Builder
-    public ChattingMessage(final Long chattingRoomId, final Long senderId,final String contents) {
+    public ChattingMessage(final Long chattingRoomId, final Long senderId,final String contents,final LocalDateTime createdAt) {
 
         this.chattingRoomId = chattingRoomId;
         this.senderId = senderId;
         this.contents = contents;
+        this.createdAt = createdAt;
     }
 
 }

--- a/src/main/java/com/gaduationproject/cre8/domain/chat/entity/ChattingMessage.java
+++ b/src/main/java/com/gaduationproject/cre8/domain/chat/entity/ChattingMessage.java
@@ -1,0 +1,40 @@
+package com.gaduationproject.cre8.domain.chat.entity;
+
+import com.gaduationproject.cre8.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "chatting") // 실제 몽고 DB 컬렉션 이름
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ChattingMessage {
+
+    @Id
+    private String id;
+
+    private Long chattingRoomId;
+
+    private Long senderId;
+
+    private String contents;
+
+    @Builder
+    public ChattingMessage(final Long chattingRoomId, final Long senderId,final String contents) {
+
+        this.chattingRoomId = chattingRoomId;
+        this.senderId = senderId;
+        this.contents = contents;
+    }
+
+}

--- a/src/main/java/com/gaduationproject/cre8/domain/chat/entity/Message.java
+++ b/src/main/java/com/gaduationproject/cre8/domain/chat/entity/Message.java
@@ -1,46 +1,46 @@
-package com.gaduationproject.cre8.domain.chat.entity;
-
-import com.gaduationproject.cre8.domain.baseentity.BaseEntity;
-import com.gaduationproject.cre8.domain.member.entity.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
-public class Message extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "message_id")
-    private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chatting_room_id",nullable = false,updatable = false)
-    private ChattingRoom chattingRoom;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sender_id",nullable = false,updatable = false)
-    private Member sender;
-
-
-    @Column(length = 500,nullable = false,updatable = false)
-    private String contents;
-
-    @Builder
-    public Message(ChattingRoom chattingRoom, Member sender, String contents) {
-        this.chattingRoom = chattingRoom;
-        this.sender = sender;
-        this.contents = contents;
-    }
-}
+//package com.gaduationproject.cre8.domain.chat.entity;
+//
+//import com.gaduationproject.cre8.domain.baseentity.BaseEntity;
+//import com.gaduationproject.cre8.domain.member.entity.Member;
+//import jakarta.persistence.Column;
+//import jakarta.persistence.Entity;
+//import jakarta.persistence.FetchType;
+//import jakarta.persistence.GeneratedValue;
+//import jakarta.persistence.GenerationType;
+//import jakarta.persistence.Id;
+//import jakarta.persistence.JoinColumn;
+//import jakarta.persistence.ManyToOne;
+//import lombok.AccessLevel;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//
+//@Entity
+//@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//@Getter
+//public class Message extends BaseEntity {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    @Column(name = "message_id")
+//    private Long id;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "chatting_room_id",nullable = false,updatable = false)
+//    private ChattingRoom chattingRoom;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "sender_id",nullable = false,updatable = false)
+//    private Member sender;
+//
+//
+//    @Column(length = 500,nullable = false,updatable = false)
+//    private String contents;
+//
+//    @Builder
+//    public Message(ChattingRoom chattingRoom, Member sender, String contents) {
+//        this.chattingRoom = chattingRoom;
+//        this.sender = sender;
+//        this.contents = contents;
+//    }
+//}

--- a/src/main/java/com/gaduationproject/cre8/domain/chat/repository/ChattingMessageRepository.java
+++ b/src/main/java/com/gaduationproject/cre8/domain/chat/repository/ChattingMessageRepository.java
@@ -1,0 +1,12 @@
+package com.gaduationproject.cre8.domain.chat.repository;
+
+import com.gaduationproject.cre8.domain.chat.entity.ChattingMessage;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChattingMessageRepository extends MongoRepository<ChattingMessage,String> {
+
+
+
+}

--- a/src/main/java/com/gaduationproject/cre8/domain/chat/repository/ChattingMessageRepository.java
+++ b/src/main/java/com/gaduationproject/cre8/domain/chat/repository/ChattingMessageRepository.java
@@ -1,12 +1,19 @@
 package com.gaduationproject.cre8.domain.chat.repository;
 
 import com.gaduationproject.cre8.domain.chat.entity.ChattingMessage;
+import com.gaduationproject.cre8.domain.chat.entity.ChattingRoom;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChattingMessageRepository extends MongoRepository<ChattingMessage,String> {
 
 
+    List<ChattingMessage> findByChattingRoomId(final Long chattingRoomId);
 
+    Optional<ChattingMessage> findTop1ByChattingRoomIdOrderByCreatedAtDesc(final Long chattingRoomId);
 }

--- a/src/main/java/com/gaduationproject/cre8/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/gaduationproject/cre8/domain/chat/repository/MessageRepository.java
@@ -1,18 +1,18 @@
-package com.gaduationproject.cre8.domain.chat.repository;
-
-import com.gaduationproject.cre8.domain.chat.entity.ChattingRoom;
-import com.gaduationproject.cre8.domain.chat.entity.Message;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-public interface MessageRepository extends JpaRepository<Message,Long> {
-
-    List<Message> findByChattingRoom(ChattingRoom chattingRoom);
-
-    @Query("select m from Message m where m.chattingRoom=:chattingRoom order by m.createdAt desc limit 1")
-    Optional<Message> findLatestMessageByChattingRoom(@Param("chattingRoom") ChattingRoom chattingRoom);
-
-}
+//package com.gaduationproject.cre8.domain.chat.repository;
+//
+//import com.gaduationproject.cre8.domain.chat.entity.ChattingRoom;
+//import com.gaduationproject.cre8.domain.chat.entity.Message;
+//import java.util.List;
+//import java.util.Optional;
+//import org.springframework.data.jpa.repository.JpaRepository;
+//import org.springframework.data.jpa.repository.Query;
+//import org.springframework.data.repository.query.Param;
+//
+//public interface MessageRepository extends JpaRepository<Message,Long> {
+//
+//    List<Message> findByChattingRoom(ChattingRoom chattingRoom);
+//
+//    @Query("select m from Message m where m.chattingRoom=:chattingRoom order by m.createdAt desc limit 1")
+//    Optional<Message> findLatestMessageByChattingRoom(@Param("chattingRoom") ChattingRoom chattingRoom);
+//
+//}


### PR DESCRIPTION
## 🔥 Related Issue
- Close #139 

## 🏃‍ Task
- 작업사항 작성 📍 관련커밋: {커밋 ID}
- 기존 chat message rdbms 즉 mysql 이 아닌
-  No sql mongo db 에 저장하여  DB 관련 IO를 줄이며 Document 구조로 관리한다 .

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?