### PR TITLE
Feat: show chatting room info with slice chatting list (#153)

### DIFF
--- a/src/main/java/com/gaduationproject/cre8/app/chat/controller/ChattingController.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/controller/ChattingController.java
@@ -2,6 +2,7 @@ package com.gaduationproject.cre8.app.chat.controller;
 
 import com.gaduationproject.cre8.app.auth.interfaces.CurrentMemberLoginId;
 import com.gaduationproject.cre8.app.chat.dto.request.ChatDto;
+import com.gaduationproject.cre8.app.chat.dto.response.ChattingRoomInfoResponseDto;
 import com.gaduationproject.cre8.app.chat.dto.response.ChattingRoomResponseDto;
 import com.gaduationproject.cre8.app.chat.dto.response.MessageResponseDto;
 import com.gaduationproject.cre8.app.chat.service.ChattingRoomService;
@@ -14,6 +15,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -60,16 +64,17 @@ public class ChattingController {
     }
 
     @GetMapping("/room/{roomId}")
-    @Operation(summary = "채팅 리스트 조회",description = "채팅방의 ID 로 채팅 리스트를 조회합니다")
+    @Operation(summary = "채팅방 채팅리스트, 방 정보 조회",description = "채팅방의 ID 로 채팅 리스트, 채팅방 정보를 조회합니다")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "500",description = "filter 가 동작하지 않았을 경우 이므로 500 반환시 알려주십시오"),
             @ApiResponse(responseCode = "404",description = "member 의 loginId 를 기반으로 조회해 오는 것을 실패 or roomId 를 기반으로 채팅방 조회 실패"),
             @ApiResponse(responseCode = "400",description = "자신이 속해 있지 않은 채팅방의 채팅 리스트에 접근 하려 할때 ")
     })
-    public ResponseEntity<BaseResponse<List<MessageResponseDto>>> showChatListByChattingRoomId(@CurrentMemberLoginId final String loginId,
-                                                                                               @PathVariable("roomId")final Long roomId){
+    public ResponseEntity<BaseResponse<ChattingRoomInfoResponseDto>> showChatListWithRoomInfoByChattingRoomId(@CurrentMemberLoginId final String loginId,
+                                                                                               @PathVariable("roomId")final Long roomId,
+                                                                                               @PageableDefault(size = 20,sort = "createdAt",direction = Direction.DESC,page = 0) final Pageable pageable){
 
-        return ResponseEntity.ok(BaseResponse.createSuccess(chattingRoomService.showChattingListByChattingRoomId(roomId,loginId)));
+        return ResponseEntity.ok(BaseResponse.createSuccess(chattingRoomService.showChattingListWithRoomInfoByChattingRoomId(roomId,loginId,pageable)));
 
 
     }

--- a/src/main/java/com/gaduationproject/cre8/app/chat/dto/response/ChattingRoomInfoResponseDto.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/dto/response/ChattingRoomInfoResponseDto.java
@@ -1,0 +1,28 @@
+package com.gaduationproject.cre8.app.chat.dto.response;
+
+import com.gaduationproject.cre8.domain.member.entity.Member;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChattingRoomInfoResponseDto {
+
+    private String opponentNickName;
+    private String opponentAccessUrl;
+    private List<MessageResponseDto> messageResponseDtoList;
+    private boolean hasNextPage;
+
+
+    public static ChattingRoomInfoResponseDto of(final Member opponent,
+            final List<MessageResponseDto> messageResponseDtoList,boolean hasNextPage) {
+
+        return new ChattingRoomInfoResponseDto(opponent.getNickName(),opponent.getAccessUrl(),messageResponseDtoList,hasNextPage);
+    }
+}

--- a/src/main/java/com/gaduationproject/cre8/domain/chat/repository/ChattingMessageRepository.java
+++ b/src/main/java/com/gaduationproject/cre8/domain/chat/repository/ChattingMessageRepository.java
@@ -5,6 +5,8 @@ import com.gaduationproject.cre8.domain.chat.entity.ChattingRoom;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -13,7 +15,7 @@ import org.springframework.stereotype.Repository;
 public interface ChattingMessageRepository extends MongoRepository<ChattingMessage,String> {
 
 
-    List<ChattingMessage> findByChattingRoomId(final Long chattingRoomId);
+    Slice<ChattingMessage> findByChattingRoomId(final Long chattingRoomId,final Pageable pageable);
 
     Optional<ChattingMessage> findTop1ByChattingRoomIdOrderByCreatedAtDesc(final Long chattingRoomId);
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #153 

## 🏃‍ Task
- 작업사항 작성 📍 관련커밋: {커밋 ID}
- 채팅방 정보 조회시 상대방 닉네임과 url 함께 반환 
- 채팅 리스트를 10개 씩 Slice 형식으로 보낼 수 있음 -> 전체는 부담스러워서?

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?