### PR TITLE
Refactor/#187 send user image with chatting room list

### DIFF
--- a/src/main/java/com/gaduationproject/cre8/app/chat/dto/response/ChattingRoomInfoResponseDto.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/dto/response/ChattingRoomInfoResponseDto.java
@@ -14,15 +14,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChattingRoomInfoResponseDto {
 
-    private String opponentNickName;
-    private String opponentAccessUrl;
+
     private List<MessageResponseDto> messageResponseDtoList;
     private boolean hasNextPage;
 
 
-    public static ChattingRoomInfoResponseDto of(final Member opponent,
-            final List<MessageResponseDto> messageResponseDtoList,boolean hasNextPage) {
+    public static ChattingRoomInfoResponseDto of(final List<MessageResponseDto> messageResponseDtoList,boolean hasNextPage) {
 
-        return new ChattingRoomInfoResponseDto(opponent.getNickName(),opponent.getAccessUrl(),messageResponseDtoList,hasNextPage);
+        return new ChattingRoomInfoResponseDto(messageResponseDtoList,hasNextPage);
     }
 }

--- a/src/main/java/com/gaduationproject/cre8/app/chat/dto/response/ChattingRoomResponseDto.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/dto/response/ChattingRoomResponseDto.java
@@ -13,14 +13,17 @@ public class ChattingRoomResponseDto {
 
     private String nickName;
 
+    private String accessUrl;
+
     private String latestMessage;
 
     private long unReadMessage;
 
     @Builder
-    public ChattingRoomResponseDto(Long roomId, String nickName, String latestMessage,long unReadMessage) {
+    public ChattingRoomResponseDto(Long roomId, String nickName,String accessUrl, String latestMessage,long unReadMessage) {
         this.roomId = roomId;
         this.nickName = nickName;
+        this.accessUrl = accessUrl;
         this.latestMessage = latestMessage;
         this.unReadMessage = unReadMessage;
     }

--- a/src/main/java/com/gaduationproject/cre8/app/chat/service/ChattingRoomService.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/service/ChattingRoomService.java
@@ -68,12 +68,7 @@ public class ChattingRoomService {
                         Sort.by("createdAt").descending()));
 
 
-        //상대방 정보
-        Member opponent = chattingRoom.getSender().getId()==currentMember.getId()?
-                          chattingRoom.getReceiver():
-                          chattingRoom.getSender();
-
-        return ChattingRoomInfoResponseDto.of(opponent,chattingMessageSlice.stream().map(MessageResponseDto::ofChatMessage).collect(
+        return ChattingRoomInfoResponseDto.of(chattingMessageSlice.stream().map(MessageResponseDto::ofChatMessage).collect(
                 Collectors.toList()), chattingMessageSlice.hasNext());
 
 
@@ -91,9 +86,10 @@ public class ChattingRoomService {
         return chattingRoomList.stream().filter(chattingRoom -> chattingMessageRepository.
                         findTop1ByChattingRoomIdOrderByCreatedAtDesc(chattingRoom.getId()).isPresent())
                         .map(chattingRoom -> {
-                            String opponentNickName = chattingRoom.getSender().getId()== currentMember.getId()
-                                    ?chattingRoom.getReceiver().getNickName()
-                                    :chattingRoom.getSender().getNickName();
+
+                            Member opponent = chattingRoom.getSender().getId()== currentMember.getId()
+                                    ?chattingRoom.getReceiver()
+                                    :chattingRoom.getSender();
 
                             ChattingMessage message = chattingMessageRepository.findTop1ByChattingRoomIdOrderByCreatedAtDesc(chattingRoom.getId())
                                     .orElseThrow(()->new InternalServerErrorException(ErrorCode.NOT_APPLY_RECENT_CHAT_FILTER));
@@ -101,7 +97,8 @@ public class ChattingRoomService {
                             return ChattingRoomResponseDto.builder()
                                     .roomId(chattingRoom.getId())
                                     .latestMessage(message.getContents())
-                                    .nickName(opponentNickName)
+                                    .nickName(opponent.getNickName())
+                                    .accessUrl(opponent.getAccessUrl())
                                     .unReadMessage(countUnReadMessages(chattingRoom.getId(),currentMember.getId()))
                                     .build();
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #187 

## 🏃‍ Task
- 작업사항 작성 📍 관련커밋: {커밋 ID}
- 기존 채팅상대방 프로필 사진 경로를 보내주는 api 를 기존 채팅 리스트와 함께 보내주는 것에서 
   전체 채팅방리스트를 가져오는 api 로 변경한다.

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?