### PR TITLE
Refactor: using @subscribemapping instead of Event (#191)

### DIFF
--- a/src/main/java/com/gaduationproject/cre8/app/chat/config/StompConfig.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/config/StompConfig.java
@@ -48,7 +48,7 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
                 .setTaskScheduler(te)
                 .setHeartbeatValue(new long[]{20000,20000});
 
-        registry.setApplicationDestinationPrefixes("/pub");
+        registry.setApplicationDestinationPrefixes("/pub","/sub");
 
 
     }

--- a/src/main/java/com/gaduationproject/cre8/app/chat/controller/ChattingController.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/controller/ChattingController.java
@@ -23,6 +23,7 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -89,6 +90,14 @@ public class ChattingController {
         chattingService.sendMessage(roomId,chatDto,simpMessageHeaderAccessor);
 
         return ResponseEntity.ok().build();
+    }
+
+    @SubscribeMapping("/chat/room/{roomId}")
+    public MessageResponseDto afterSubscribe(@DestinationVariable("roomId") final Long roomId, final SimpMessageHeaderAccessor simpMessageHeaderAccessor){
+
+        return chattingService.sendEnterMessageAfterSubscribe(roomId,simpMessageHeaderAccessor.getUser().getName(),
+                                                               simpMessageHeaderAccessor);
+
     }
 
 //    @MessageMapping("message.{roomId}")

--- a/src/main/java/com/gaduationproject/cre8/app/chat/handler/WebSocketEventListener.java
+++ b/src/main/java/com/gaduationproject/cre8/app/chat/handler/WebSocketEventListener.java
@@ -37,23 +37,23 @@ public class WebSocketEventListener {
         log.info("disconnect 끊김");
     }
 
-    @EventListener
-    public void handleWebSocketSubscribeListener(SessionSubscribeEvent event){
-
-        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
-
-        final Long chattingRoomId = Long.valueOf(headerAccessor.getSubscriptionId());
-        final String loginId = headerAccessor.getUser().getName();
-
-        chattingRoomConnectService.connectChattingRoom(chattingRoomId,loginId,headerAccessor.getSessionId());
-        chattingService.sendEnterMessage(chattingRoomId,loginId);
-        chattingService.updateCountAllZero(chattingRoomId,loginId);
-
-        headerAccessor.getSessionAttributes().put(SUB,chattingRoomId);
-
-
-        log.info("채팅방 입장: chattingRoomId: {}",chattingRoomId);
-    }
+//    @EventListener
+//    public void handleWebSocketSubscribeListener(SessionSubscribeEvent event){
+//
+//        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+//
+//        final Long chattingRoomId = Long.valueOf(headerAccessor.getSubscriptionId());
+//        final String loginId = headerAccessor.getUser().getName();
+//
+//        chattingRoomConnectService.connectChattingRoom(chattingRoomId,loginId,headerAccessor.getSessionId());
+//        chattingService.sendEnterMessage(chattingRoomId,loginId);
+//        chattingService.updateCountAllZero(chattingRoomId,loginId);
+//
+//        headerAccessor.getSessionAttributes().put(SUB,chattingRoomId);
+//
+//
+//        log.info("채팅방 입장: chattingRoomId: {}",chattingRoomId);
+//    }
 
     @EventListener
     public void handleWebSocketUnsubscribeListener(SessionUnsubscribeEvent event) {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #이슈번호
- #191 

## 🏃‍ Task
- 작업사항 작성 📍 관련커밋: {커밋 ID}
- @SubscribeMapping 을 WebSocketSessionEvent 대신 활용하여 실제 구독이 완료되었을 때만 메시지를 보내도록 한다. 

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?