### PR TITLE
Bug/#200 child tag double

### DIFF
--- a/src/main/java/com/gaduationproject/cre8/app/employmentpost/dto/response/EmployeePostResponseDto.java
+++ b/src/main/java/com/gaduationproject/cre8/app/employmentpost/dto/response/EmployeePostResponseDto.java
@@ -30,6 +30,7 @@ public class EmployeePostResponseDto {
     private Long writerId;
     private String writerNickName;
     private String writerAccessUrl;
+    private String writerLoginId;
     private boolean isBookMarked;
 
 
@@ -58,6 +59,7 @@ public class EmployeePostResponseDto {
                 writer.getId(),
                 writer.getNickName(),
                 writer.getAccessUrl(),
+                writer.getLoginId(),
                 isBookMarked);
 
     }

--- a/src/main/java/com/gaduationproject/cre8/app/member/dto/LoginIdRequestDto.java
+++ b/src/main/java/com/gaduationproject/cre8/app/member/dto/LoginIdRequestDto.java
@@ -3,6 +3,7 @@ package com.gaduationproject.cre8.app.member.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,5 +16,15 @@ public class LoginIdRequestDto {
     @NotBlank(message = "가입한 로그인 아이디를 입력해주세요")
     @Schema(description = "로그인 아이디",example = "dionisos198")
     private String loginId;
+
+    @NotBlank(message = "사용자의 이름을 입력해주세요")
+    @Schema(description = "사용자 이름",example = "이진우")
+    private String name;
+
+    @Email(message = "이메일 형식에 맞지 않습니다")
+    @NotEmpty(message = "이메일을 입력해 주세요")
+    @Schema(description = "사용자의 이메일",example = "dionisos198@naver.com")
+    private String email;
+
 
 }

--- a/src/main/java/com/gaduationproject/cre8/app/member/service/MemberMailSendService.java
+++ b/src/main/java/com/gaduationproject/cre8/app/member/service/MemberMailSendService.java
@@ -70,6 +70,8 @@ public class MemberMailSendService {
         Member member = memberRepository.findMemberByLoginId(loginIdRequestDto.getLoginId())
                 .orElseThrow(()-> new NotFoundException(ErrorCode.CANT_FIND_MEMBER));
 
+        checkValidateUser(loginIdRequestDto,member);
+
         String tmpPassword = generateRandomString(7);
 
         mailService.sendMail(member.getEmail(),mailTitle,mailContentsTMPPasswordBefore
@@ -79,6 +81,18 @@ public class MemberMailSendService {
         member.changePassword(passwordEncoder.encode(tmpPassword));
         member.changeStatusToTMPPassword();
 
+    }
+
+    private void checkValidateUser(final LoginIdRequestDto loginIdRequestDto, final Member member) {
+
+        if(member.getEmail().equals(loginIdRequestDto.getEmail()) &&
+           member.getLoginId().equals(loginIdRequestDto.getLoginId()) &&
+           member.getName().equals(loginIdRequestDto.getName())){
+
+            return;
+        }
+
+        throw new BadRequestException(ErrorCode.CANT_REQUEST_TMP_PW);
     }
 
     //임의의 6자리 양수를 반환합니다.

--- a/src/main/java/com/gaduationproject/cre8/common/response/error/ErrorCode.java
+++ b/src/main/java/com/gaduationproject/cre8/common/response/error/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     CANT_MAKE_RE_RE_REPLY("대대댓글은 만들 수 없습니다"),
     CANT_ACCESS_COMMUNITY_POST("자신의 게시글만 수정,삭제 할 수 있습니다"),
     CANT_ACCESS_REPLY("자신의 댓글만 수정,삭제 할 수 있습니다"),
+    CANT_REQUEST_TMP_PW("사용자의 정보를 정확히 입력해주세요"),
 
 
 


### PR DESCRIPTION
## 🔥 Related Issue
- Close #이슈번호
- #200 
- 

## 🏃‍ Task
- 작업사항 작성 📍 관련커밋: {커밋 ID}
- 구직글에서 child tag가 2개씩 나오는 이유 분석 -> 프론트에서 2개씩 설정 하여 저장하는 듯?
- 임시 비밀번호 세팅 시 이메일, 이름, loginID 필요 로 전환
-  EmployerPost 조회 시 사용자의 로그인 아이디도 함께 반환 

## 📄 Reference
- None

## ✅ Check List
- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?